### PR TITLE
Fix captcha on multipage survey

### DIFF
--- a/Products/PloneSurvey/content/SubSurvey.py
+++ b/Products/PloneSurvey/content/SubSurvey.py
@@ -136,6 +136,22 @@ class SubSurvey(ATCTOrderedFolder):
                 return page()
         return self.exitSurvey()
 
+    security.declareProtected(permissions.View, 'hasMorePages')
+
+    def hasMorePages(self):
+        """Return True if survey has more pages to display"""
+        previous_page = True
+        parent = self.aq_parent
+        pages = parent.getFolderContents(
+            contentFilter={'portal_type': 'Sub Survey', }, full_objects=True)
+        for page in pages:
+            if previous_page:
+                if page.getId() == self.getId():
+                    previous_page = False
+            elif page.displaySubSurvey():
+                return True
+        return False
+
     security.declareProtected(permissions.View, 'displaySubSurvey')
 
     def displaySubSurvey(self):

--- a/Products/PloneSurvey/content/Survey.py
+++ b/Products/PloneSurvey/content/Survey.py
@@ -286,6 +286,16 @@ class Survey(ATCTOrderedFolder):
                 return page()
         return self.exitSurvey()
 
+    security.declareProtected(permissions.View, 'hasMorePages')
+
+    def hasMorePages(self):
+        """Return True if survey has more pages to display"""
+        pages = self.getFolderContents(
+            contentFilter={'portal_type': 'Sub Survey', }, full_objects=True)
+        if not pages:
+            return False
+        return True
+
     security.declareProtected(permissions.View, 'exitSurvey')
 
     def exitSurvey(self):

--- a/Products/PloneSurvey/skins/plone_survey/survey_view.cpt
+++ b/Products/PloneSurvey/skins/plone_survey/survey_view.cpt
@@ -80,7 +80,7 @@
                           tal:content="structure question/getBody" />
                 </tal:question>
 
-                <tal:captcha tal:condition="python:show_captcha and (captcha_installed or recaptcha_enabled)">
+                <tal:captcha tal:condition="python:show_captcha and (captcha_installed or recaptcha_enabled) and not context.hasMorePages()">
                     <tal:captcha_installed tal:condition="captcha_installed">
                         <div metal:use-macro="here/captcha_widget/macros/captcha" />
                     </tal:captcha_installed>

--- a/Products/PloneSurvey/skins/plone_survey/validate_survey.vpy
+++ b/Products/PloneSurvey/skins/plone_survey/validate_survey.vpy
@@ -72,7 +72,7 @@ for q in questions:
             state.setError(q.getId(), "%s %s" % (error_msg, qnum))
 
 if not state.getErrors():
-    if context.getShowCaptcha():
+    if context.getShowCaptcha() and not context.hasMorePages():
         if context.isCaptchaInstalled():
             context.captcha_validator()
         else:

--- a/Products/PloneSurvey/tests/testReCaptcha.py
+++ b/Products/PloneSurvey/tests/testReCaptcha.py
@@ -50,3 +50,40 @@ class testReCaptcha(unittest.TestCase):
         )
         assert controller_state.getErrors() != {}, \
             "Validation error raised: %s" % controller_state.getErrors()
+
+
+class testReCaptchaSubSurveys(unittest.TestCase):
+    """
+    Ensure captcha works correctly on multipage survey.
+    Captcha mut be provided only on the last page
+    """
+    layer = INTEGRATION_RECAPTCHA_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        setRoles(self.portal, TEST_USER_ID, ['Manager'])
+        self.portal.invokeFactory('Survey', 's1')
+        self.s1 = getattr(self.portal, 's1')
+        self.s1.invokeFactory('Survey Text Question', 'stq1',
+                              title="Question 1")
+        self.s1.setShowCaptcha(True)
+        self.s1.invokeFactory('Sub Survey', 'subs1')
+        self.s1.subs1.invokeFactory('Survey Text Question', 'stq2',
+                                    title="Question 2")
+        recapcha_settings = getRecaptchaSettings()
+        recapcha_settings.public_key = 'foo'
+        recapcha_settings.private_key = 'bar'
+        self.layer['request'].set('ACTUAL_URL', self.s1.absolute_url())
+
+    def testPage1(self):
+        """Test that captcha is NOT included on the first page"""
+        result = self.s1.survey_view(REQUEST=Request())
+        assert "Question 1" in result
+        assert "recaptcha_response_field" not in result
+
+    def testLastPage(self):
+        """Test that captcha is included on the last page"""
+        self.s1.stq1._addAnswer(TEST_USER_ID, "Foo")
+        result = self.s1.getNextPage()
+        assert "Question 2" in result
+        assert "recaptcha_response_field" in result

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -3,6 +3,10 @@ Changelog for Products.PloneSurvey
 
 1.4.9 - Unreleased
 ------------------
+
+  * On a multipage survey only display captcha on last page
+    [keul]
+
   * Fix typo in `getValidationQuestions` method that breaks SubSurvey creation
     when a Select question was created in the form
     [cekk]


### PR DESCRIPTION
If you enable captcha protection on a multiapge survey you'll get the captcha field on every page.

Commonly the captcha is only needed once, having it multiple time is really frustrating