### PR TITLE
Fix user -> users checkbox name attribute

### DIFF
--- a/Products/PloneSurvey/skins/plone_survey/respondents_view.cpt
+++ b/Products/PloneSurvey/skins/plone_survey/respondents_view.cpt
@@ -57,7 +57,7 @@
                                        name="answer"
                                        value="option"
                                        tal:attributes="value user;
-                                                       name string:user;" />
+                                                       name string:users;" />
                             </td>
                             <td>
                                 <span tal:replace="python:context.getRespondentFullName(user) or user" />


### PR DESCRIPTION
This was (probably by mistake) changed in commit f5225b8f without also
changing the corresponding code in respondents_reset.vpy. As the old
variable name seems more correct, this commit changes the template back
to use the old name.